### PR TITLE
config: Enable Allstar Actions policy with Scorecard Action requirement rule

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,12 @@
+optConfig:
+  optOutStrategy: true
+action: issue
+groups:
+  - name: "All repos"
+    rules:
+      - name: "Require Scorecard Action"
+        method: require
+        priority: medium
+        actions:
+          - name: "ossf/scorecard-action"
+            version: ">= v1.1.2"


### PR DESCRIPTION
Require ossf/scorecard-action@ >= v1.1.2 for [enabled repos](https://github.com/angular/.allstar/blob/main/allstar.yaml#L2)